### PR TITLE
Make unicode labels for with Python 2

### DIFF
--- a/asciitree/drawing.py
+++ b/asciitree/drawing.py
@@ -42,7 +42,7 @@ BOX_BLANK = {
 
 class Style(KeyArgsConstructor):
     """Rendering style for trees."""
-    label_format = '{}'  #: Format for labels.
+    label_format = u'{}'  #: Format for labels.
 
     def node_label(self, text):
         """Render a node text into a label."""

--- a/tests/test_unicode.py
+++ b/tests/test_unicode.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+from asciitree import LeftAligned
+
+def test_unicode_doesnt_crash():
+    tr = LeftAligned()
+    assert tr({u"åäö": {}}) == u"åäö"


### PR DESCRIPTION
This simple fix makes unicode labels work on Python 2. Fixes #2.

I also had to add a `__init__.py` file in the tests directory to be able to run the tests with `python tests/*`, hope that was ok.

As a convenience, I also ignored .pyc files in the project. 

If you don't want the other changes, let me know and I'll remove them from the pull request. 
