### PR TITLE
correct rst to improve pypi documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 ASCII Trees
 ===========
 
-::
+.. code:: console
 
   asciitree
    +-- sometimes
@@ -16,9 +16,7 @@ ASCII Trees
            +-- terminal
 
 
-.. highlight:: python
-
-::
+.. code:: python
 
   from asciitree import LeftAligned
   from collections import OrderedDict as OD


### PR DESCRIPTION
The current (long description) documentation does not render correctly on pypi (or on warehouse). This change removes the elements in the restructured text that were causing the render to fail, and has the side effect of adding syntax coloring
