### PR TITLE
Add MANIFEST.in to include LICENSE in tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE


### PR DESCRIPTION
I maintain the [package](https://github.com/conda-forge/asciitree-feedstock) for asciitree on [conda-forge](https://conda-forge.github.io/). I would like to include your license file into that package but I currently can't do that because it isn't included in the tarball uploaded to pypi. The `MANIFEST.in` file added in this PR will add the license to the next release you make on pypi.
