### PR TITLE
Include docs, tests, and example.py in PyPI tarball.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,4 @@
 include LICENSE
+graft docs
+graft tests
+include example.py


### PR DESCRIPTION
Hi!

This would be nice for downstream re-packagers of this (awesome) lib, like Linux distros.  We like to pull down the tarball from PyPI just like everybody else, but then it's nice to be able to re-run your test suite before we push the "go" button on a new package update.

Cheers!
