### PR TITLE
Handle first child specially

### DIFF
--- a/asciitree/__init__.py
+++ b/asciitree/__init__.py
@@ -66,6 +66,18 @@ class LegacyStyle(Style):
     def node_label(self, text):
         return text
 
+    def only_child_head(self, label):
+        return self.last_child_head(label)
+
+    def only_child_tail(self, line):
+        return self.last_child_tail(line)
+
+    def first_child_head(self, label):
+        return self.child_head(label)
+
+    def first_child_tail(self, line):
+        return self.child_tail(line)
+
     def child_head(self, label):
         return '  +--' + label
 

--- a/asciitree/__init__.py
+++ b/asciitree/__init__.py
@@ -29,7 +29,11 @@ class LeftAligned(KeyArgsConstructor):
         for n, child in enumerate(children):
             child_tree = self.render(child)
 
-            if n == len(children) - 1:
+            if n == 0:
+                lines.append(self.draw.first_child_head(child_tree.pop(0)))
+                lines.extend(self.draw.first_child_tail(l)
+                             for l in child_tree)
+            elif n == len(children) - 1:
                 # last child does not get the line drawn
                 lines.append(self.draw.last_child_head(child_tree.pop(0)))
                 lines.extend(self.draw.last_child_tail(l)

--- a/asciitree/__init__.py
+++ b/asciitree/__init__.py
@@ -29,7 +29,11 @@ class LeftAligned(KeyArgsConstructor):
         for n, child in enumerate(children):
             child_tree = self.render(child)
 
-            if n == 0:
+            if n == 0 and n == len(children) - 1:
+                lines.append(self.draw.only_child_head(child_tree.pop(0)))
+                lines.extend(self.draw.only_child_tail(l)
+                             for l in child_tree)
+            elif n == 0:
                 lines.append(self.draw.first_child_head(child_tree.pop(0)))
                 lines.extend(self.draw.first_child_tail(l)
                              for l in child_tree)

--- a/asciitree/drawing.py
+++ b/asciitree/drawing.py
@@ -48,6 +48,16 @@ class Style(KeyArgsConstructor):
         """Render a node text into a label."""
         return self.label_format.format(text)
 
+    def first_child_head(self, label):
+        """Like :func:`~asciitree.drawing.Style.child_head` but only called
+        for the first child."""
+        return label
+
+    def first_child_tail(self, line):
+        """Like :func:`~asciitree.drawing.Style.child_tail` but only called
+        for the first child."""
+        return line
+
     def child_head(self, label):
         """Render a node label into final output."""
         return label
@@ -73,6 +83,12 @@ class BoxStyle(Style):
     label_space = 1   #: Space between glyphs and label.
     horiz_len = 2     #: Length of horizontal lines
     indent = 1        #: Indent for subtrees
+
+    def first_child_head(self, label):
+        return self.child_head(label)
+
+    def first_child_tail(self, line):
+        return self.child_tail(line)
 
     def child_head(self, label):
         return (' ' * self.indent

--- a/asciitree/drawing.py
+++ b/asciitree/drawing.py
@@ -94,6 +94,12 @@ class BoxStyle(Style):
     horiz_len = 2     #: Length of horizontal lines
     indent = 1        #: Indent for subtrees
 
+    def only_child_head(self, label):
+        return self.last_child_head(label)
+
+    def only_child_tail(self, line):
+        return self.last_child_tail(line)
+
     def first_child_head(self, label):
         return self.child_head(label)
 

--- a/asciitree/drawing.py
+++ b/asciitree/drawing.py
@@ -48,6 +48,16 @@ class Style(KeyArgsConstructor):
         """Render a node text into a label."""
         return self.label_format.format(text)
 
+    def only_child_head(self, label):
+        """Like :func:`~asciitree.drawing.Style.child_head` but only called
+        for the only child."""
+        return label
+
+    def only_child_tail(self, line):
+        """Like :func:`~asciitree.drawing.Style.child_tail` but only called
+        for the only child."""
+        return line
+
     def first_child_head(self, label):
         """Like :func:`~asciitree.drawing.Style.child_head` but only called
         for the first child."""


### PR DESCRIPTION
Closes https://github.com/mbr/asciitree/issues/10

Adds `first_child_head` and `first_child_tail` to `Style` and implements them in a compatible way for `BoxStyle`. Updates `LeftAligned` to handle the first child with these special methods.