### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "python example.py"

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,8 @@
 ASCII Trees
 ===========
 
+[![Run on Repl.it](https://repl.it/badge/github/mbr/asciitree)](https://repl.it/github/mbr/asciitree)
+
 .. code:: console
 
   asciitree


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@joshwood/asciitree).